### PR TITLE
Add `preprocess` hook for custom content transformations before MJML compilation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-node_modules
-public
-vendor
-**/dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-	"extends": "@innocenzi/eslint-config"
-}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,22 +8,16 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.9
 
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npx conventional-github-releaser -p angular
         continue-on-error: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -18,11 +18,10 @@ jobs:
         with:
           version: 6.27.0
 
-      - name: Use Node.js v16
-        uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: v16
-          registry-url: https://registry.npmjs.org/
+          node-version: 24
           cache: 'pnpm'
 
       - run: npx conventional-github-releaser -p angular

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,16 +8,22 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npx conventional-github-releaser -p angular
         continue-on-error: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,21 +8,22 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 6.27.0
+        uses: pnpm/action-setup@v6.0.9
 
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npx conventional-github-releaser -p angular
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,14 +2,15 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
-      - '**'
-      - '!readme.md'
-      - '!docs/**'
-      - '!packages/**/package.json'
+      - '**.js'
+      - '**.ts'
+      - '.github/workflows/test.yaml'
   pull_request:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -22,23 +23,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node: [ 20, 22, 24 ]
         os: [ubuntu-latest, windows-latest]
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 6.24.4
+        uses: pnpm/action-setup@v6.0.9
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-          registry-url: https://registry.npmjs.org/
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
       - run: pnpm install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      DEBUG: 'preset:*'
+      DEBUG: 'vite:mjml*'
 
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+
       - name: Setup node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: true
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,16 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.9
-
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
-      - run: pnpm install
+      - name: Install Dependencies
+        run: pnpm install
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         node: [ 20, 22, 24 ]
         os: [ubuntu-latest, windows-latest]
-      fail-fast: true
 
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -57,6 +57,31 @@ Similarly, when building for production, all files in `input` will be compiled a
 | `mjml`      | `MJMLParsingOptions` | Specific MJML [compiler options](https://documentation.mjml.io/#inside-node-js)          | `{}`             |
 | `watch`     | `boolean`            | Whether to watch and compile on the fly in development mode                              | `true`           |
 | `log`       | `boolean`            | Whether to print output in the console                                                   | `true`           |
+| `preprocess`| `(content: string, filePath: string) => string` | Transforms the raw file contents before they reach the MJML compiler        | `undefined`      |
+
+&nbsp;
+
+### `preprocess`
+
+The `preprocess` hook lets you transform the raw contents of each `.mjml` file
+*before* it is passed to the MJML compiler. It receives the file contents and the
+path of the file being compiled, and returns the source to compile.
+
+This is useful for injecting or rewriting content that MJML would otherwise strip.
+For example, wrapping templating directives in `<mj-raw>`:
+
+```ts
+mjml({
+	input: 'resources/mail',
+	output: 'resources/views/emails',
+	preprocess: (content, filePath) => content.replace(
+		/({(?:if|foreach|assign)[^}]*})/g,
+		'<mj-raw>$1</mj-raw>',
+	),
+})
+```
+
+When `preprocess` is omitted, the file contents are passed to MJML unchanged.
 
 <p align="center">
 	<br />

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,13 @@
+import { defineEslintConfig } from '@innocenzi/eslint-config'
+
+export default defineEslintConfig(
+	{},
+	{
+		ignores: [
+			'**/node_modules',
+			'**/dist',
+			'**/public',
+			'**/vendor',
+		],
+	},
+)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "npm run build",
     "build": "unbuild",
     "test": "vitest",
-    "lint": "eslint src/*.ts",
+    "lint": "eslint src",
     "release": "bumpp --push --tag --commit \"release: v\""
   },
   "dependencies": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,13 +17,21 @@ export function compileInput(input: string, options: CompileOptions) {
 		? options.exclude
 		: [options.exclude]
 
-	if (excludes.map((exclude) => path.resolve(exclude)).some((exclude: string) => path.resolve(input).startsWith(normalizePath(exclude)))) {
+	const normalizedInput = normalizePath(path.resolve(input))
+	const isExcluded = excludes.some((exclude) => {
+		const normalizedExclude = normalizePath(path.resolve(exclude))
+
+		// Match the excluded path itself or any file nested under it.
+		return normalizedInput === normalizedExclude || normalizedInput.startsWith(`${normalizedExclude}/`)
+	})
+
+	if (isExcluded) {
 		return
 	}
 
 	debug.compile('Compiling input:', { input, options })
 
-	const log = options.log === false
+	const log = !options.log
 		? () => {}
 		: options.building
 			? (text: string) => console.log(`${c.cyan(c.bold('mjml'))} - ${text}`)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import fs from 'node:fs'
 import path from 'node:path'
-import { normalizePath } from "vite";
-import { Plugin } from 'vite'
+import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
 import mjml from 'mjml'
 import fg from 'fast-glob'
 import c from 'picocolors'
@@ -17,7 +17,7 @@ export function compileInput(input: string, options: CompileOptions) {
 		? options.exclude
 		: [options.exclude]
 
-	if (excludes.map(exclude => path.resolve(exclude)).some((exclude: string) => path.resolve(input).startsWith(normalizePath(exclude)))) {
+	if (excludes.map((exclude) => path.resolve(exclude)).some((exclude: string) => path.resolve(input).startsWith(normalizePath(exclude)))) {
 		return
 	}
 
@@ -55,10 +55,10 @@ export function compileInput(input: string, options: CompileOptions) {
 	}
 }
 
-export default function(options: Partial<Options> = {}): Plugin {
+export default function (options: Partial<Options> = {}): Plugin {
 	let compileOptions: CompileOptions
 
-	const compileFiles = async(paths: string) => {
+	const compileFiles = async (paths: string) => {
 		let input = ''
 
 		if (paths.includes('*')) {
@@ -70,7 +70,7 @@ export default function(options: Partial<Options> = {}): Plugin {
 		const files = await fg(input)
 		debug.mjml('Compiling MJML files:', { input, files })
 		files.forEach((file) => {
-			compileInput(file, compileOptions);
+			compileInput(file, compileOptions)
 		})
 	}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,9 +30,10 @@ export function compileInput(input: string, options: CompileOptions) {
 			: (text: string) => options.logger.info(text, { timestamp: true })
 
 	const content = fs.readFileSync(input, 'utf-8')
+	const source = options.preprocess ? options.preprocess(content, input) : content
 
 	try {
-		const result = mjml(content, options.mjml)
+		const result = mjml(source, options.mjml)
 		const outputFile = input
 			.replace(normalizePath(options.input), normalizePath(options.output))
 			.replace('.mjml', options.extension)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { MJMLParsingOptions } from 'mjml-core'
-import { Logger } from 'vite'
+import type { MJMLParsingOptions } from 'mjml-core'
+import type { Logger } from 'vite'
 
 export interface Options {
 	input: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,14 @@ export interface Options {
 	watch: boolean
 	log: boolean
 	mjml?: MJMLParsingOptions
+	/**
+	 * Transforms the raw file contents before they are passed to the MJML compiler.
+	 *
+	 * @param content The raw contents read from the `.mjml` file.
+	 * @param filePath The path of the file being compiled.
+	 * @returns The source to compile with MJML.
+	 */
+	preprocess?: (content: string, filePath: string) => string
 }
 
 export interface CompileOptions extends Options {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -48,6 +48,60 @@ test('it can exclude directories', async() => {
 	expect(!fs.existsSync(path.resolve(output, 'partials', '_foo.html'))).toBe(true)
 })
 
+test('it runs preprocess before compiling', async() => {
+	expect(fs.existsSync(output)).toBe(false)
+
+	const seen: string[] = []
+
+	await build({
+		root: fixtures,
+		logLevel: 'silent',
+		plugins: [
+			mjml({
+				log: false,
+				extension: '.html',
+				input: path.resolve(fixtures, 'valid'),
+				output,
+				preprocess: (content, filePath) => {
+					seen.push(filePath)
+					return content.replace('Hello World', 'Goodbye World')
+				},
+			}),
+		],
+	})
+
+	const compiled = fs.readFileSync(path.resolve(output, 'mail', 'mail.html'), 'utf-8')
+
+	// The rewritten token reached the MJML compiler...
+	expect(compiled).toContain('Goodbye World')
+	// ...and the original token is gone.
+	expect(compiled).not.toContain('Hello World')
+	// The file path was passed as the second argument.
+	expect(seen).toContain(path.resolve(fixtures, 'valid', 'mail', 'mail.mjml').replace(/\\/g, '/'))
+})
+
+test('it compiles unchanged when preprocess is omitted', async() => {
+	expect(fs.existsSync(output)).toBe(false)
+
+	await build({
+		root: fixtures,
+		logLevel: 'silent',
+		plugins: [
+			mjml({
+				log: false,
+				extension: '.html',
+				input: path.resolve(fixtures, 'valid'),
+				output,
+			}),
+		],
+	})
+
+	const compiled = fs.readFileSync(path.resolve(output, 'mail', 'mail.html'), 'utf-8')
+
+	expect(compiled).toContain('Hello World')
+	expect(compiled).not.toContain('Goodbye World')
+})
+
 test('it throws on compilation errors', async() => {
 	expect(fs.existsSync(output)).toBe(false)
 


### PR DESCRIPTION
Added the option to run preprocessing, for example to wrap smarty with mj-raw tags. The preprocessing could be anything tho, implemented in the project that uses this plugin.